### PR TITLE
enable SNS and SQS service and upgrade for Go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: go
 sudo: false
 go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
 
 install:
-  - go get gopkg.in/yaml.v2
-  - go get gotest.tools/assert
+  - go mod download
   - go get github.com/mattn/goveralls
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-FROM golang:onbuild as build
+FROM golang:1.13.5-alpine3.10 as build
 Maintainer Mahmoud Gamal <mhmoudgmal.89@gmail.com>
 
-RUN go get gopkg.in/yaml.v2 &\
-    go get gotest.tools/assert
+RUN apk update && apk add git gcc musl-dev
 
+ENV APP_HOME /build-app
+
+WORKDIR $APP_HOME
+
+COPY go.mod $APP_HOME
+COPY go.sum $APP_HOME
+RUN go mod download
+
+COPY . $APP_HOME
 RUN go test -v
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o localstack-single-endpoint
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o localstack-single-endpoint .
 
 FROM alpine as app
 Maintainer Mahmoud Gamal <mhmoudgmal.89@gmail.com>
 
-COPY --from=build /go/src/app/localstack-single-endpoint /
-COPY --from=build /go/src/app/services.yml /
+COPY --from=build /build-app/localstack-single-endpoint /
+COPY --from=build /build-app/services.yml /
 
 ENV LOCALSTACK_HOST "localhost"
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/mhmoudgmal/localstack-single-endpoint
+
+go 1.13
+
+require (
+	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	gopkg.in/yaml.v2 v2.2.7
+	gotest.tools v2.2.0+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/request_forwarder_test.go
+++ b/request_forwarder_test.go
@@ -54,7 +54,7 @@ func TestForward_noLocalstackBackendDetected(t *testing.T) {
 }
 
 func TestForward_supportedLocalstackBackends(t *testing.T) {
-	services := []string{"s3", "lambda", "apigateway", "dynamodb", "kinesis"}
+	services := []string{"s3", "lambda", "apigateway", "dynamodb", "kinesis", "sns", "sqs"}
 
 	expectedBodyRegx := `^Post http://.*:\d{4}/: dial tcp .*:\d{4}: .*: connection refused$`
 	r := regexp.MustCompile(expectedBodyRegx)

--- a/services.yml
+++ b/services.yml
@@ -13,3 +13,9 @@ apigateway:
 kinesis:
   Host: localhost
   Port: 4568
+sns:
+  Host: localhost
+  Port: 4575
+sqs:
+  Host: localhost
+  Port: 4576

--- a/services_test.go
+++ b/services_test.go
@@ -13,6 +13,8 @@ var services = Services{
 	"kinesis":    Backend{Host: "localhost", Port: "4568"},
 	"dynamodb":   Backend{Host: "localhost", Port: "4569"},
 	"apigateway": Backend{Host: "localhost", Port: "4567"},
+	"sns":        Backend{Host: "localhost", Port: "4575"},
+	"sqs":        Backend{Host: "localhost", Port: "4576"},
 }
 
 func TestDefaultLocalstackEndpointst(t *testing.T) {
@@ -23,7 +25,7 @@ func TestDefaultLocalstackEndpointst(t *testing.T) {
 }
 
 func TestNames(t *testing.T) {
-	expectedServicesNames := []string{"s3", "lambda", "kinesis", "dynamodb", "apigateway"}
+	expectedServicesNames := []string{"s3", "lambda", "kinesis", "dynamodb", "apigateway", "sns", "sqs"}
 	got := services.Names()
 
 	sort.Strings(got)


### PR DESCRIPTION
I needed to enable SQS and SNS services but when building the image I received the error

```shell
Step 3/12 : RUN go get gopkg.in/yaml.v2 &    go get gotest.tools/assert
 ---> Running in 77f9468303a5
package gotest.tools/v3/assert/cmp: cannot find package "gotest.tools/v3/assert/cmp" in any of:
	/usr/local/go/src/gotest.tools/v3/assert/cmp (from $GOROOT)
	/go/src/gotest.tools/v3/assert/cmp (from $GOPATH)
package gotest.tools/v3/internal/format: cannot find package "gotest.tools/v3/internal/format" in any of:
	/usr/local/go/src/gotest.tools/v3/internal/format (from $GOROOT)
	/go/src/gotest.tools/v3/internal/format (from $GOPATH)
package gotest.tools/v3/internal/source: cannot find package "gotest.tools/v3/internal/source" in any of:
	/usr/local/go/src/gotest.tools/v3/internal/source (from $GOROOT)
	/go/src/gotest.tools/v3/internal/source (from $GOPATH)
ERROR: Service 'awsproxy' failed to build: The command '/bin/sh -c go get gopkg.in/yaml.v2 &    go get gotest.tools/assert' returned a non-zero code: 1
```

After a few tries resolving to upgrade the project to GO Modules and everything worked wonderfully